### PR TITLE
Added the ability to retrieve the embed token for reports

### DIFF
--- a/src/API/Dashboard.php
+++ b/src/API/Dashboard.php
@@ -15,6 +15,7 @@ class Dashboard
     const GROUP_DASHBOARD_URL = "https://api.powerbi.com/v1.0/myorg/groups/%s/dashboards";
     const TILES_URL = "https://api.powerbi.com/v1.0/myorg/dashboards/%s/tiles";
     const GROUP_TILES_URL = "https://api.powerbi.com/v1.0/myorg/groups/%s/dashboards/%s/tiles";
+    const GROUP_DASHBOARD_EMBED_URL = "https://api.powerbi.com/v1.0/myorg/groups/%s/dashboards/%s/GenerateToken";
 
     /**
      * The SDK client
@@ -49,6 +50,28 @@ class Dashboard
         return $this->client->generateResponse($response);
     }
 
+    /**
+     * Retrieves the embed token for embedding a dashboard
+     *
+     * @param string      $dashboardId The dashboard ID
+     * @param string      $groupId     The group ID of the dashboard
+     * @param null|string $accessLevel The access level used for the dashboard
+     *
+     * @return \Tngnt\PBI\Response
+     */
+    public function getDashboardEmbedToken($dashboardId, $groupId, $accessLevel = 'view')
+    {
+        $url = sprintf(self::GROUP_DASHBOARD_EMBED_URL, $groupId, $dashboardId);
+
+        $body = [
+                        'accessLevel' => $accessLevel,
+        ];
+
+        $response = $this->client->request(Client::METHOD_POST, $url, $body);
+
+        return $this->client->generateResponse($response);
+    }
+    
     /**
      * Retrieves the tiles on a specified dashboard
      *

--- a/src/API/Report.php
+++ b/src/API/Report.php
@@ -12,7 +12,8 @@ use Tngnt\PBI\Client;
 class Report
 {
     const REPORT_URL = "https://api.powerbi.com/v1.0/myorg/reports";
-    const GROUP_REPORT_URL = "https://api.powerbi.com/beta/myorg/groups/%s/reports";
+    const GROUP_REPORT_URL = "https://api.powerbi.com/v1.0/myorg/groups/%s/reports";
+    const GROUP_REPORT_EMBED_URL = "https://api.powerbi.com/v1.0/myorg/groups/%s/reports/%s/GenerateToken";
 
     /**
      * The SDK client
@@ -43,6 +44,28 @@ class Report
         $url = $this->getUrl($groupId);
 
         $response = $this->client->request(Client::METHOD_GET, $url);
+
+        return $this->client->generateResponse($response);
+    }
+
+    /**
+     * Retrieves the embed token for embedding a report
+     *
+     * @param string      $reportId    The report ID of the report
+     * @param string      $groupId     The group ID of the report
+     * @param null|string $accessLevel The access level used for the report
+     *
+     * @return \Tngnt\PBI\Response
+     */
+    public function getReportEmbedToken($reportId, $groupId, $accessLevel = 'view')
+    {
+        $url = sprintf(self::GROUP_REPORT_EMBED_URL, $groupId, $reportId);
+
+        $body = [
+            'accessLevel' => $accessLevel,
+        ];
+
+        $response = $this->client->request(Client::METHOD_POST, $url, $body);
 
         return $this->client->generateResponse($response);
     }

--- a/src/Client.php
+++ b/src/Client.php
@@ -280,12 +280,13 @@ class Client
             'headers' => [
                 "Accept"        => "application/json",
                 "Authorization" => sprintf("Bearer %s", $this->getToken()),
+            	"Content-Type"  => "application/json",
             ]
         ];
 
         // Add body if one was provided.
         if ($body) {
-            $requestOptions = array_merge($requestOptions, ['json' => json_encode($body)]);
+            $requestOptions = array_merge($requestOptions, ['body' => json_encode($body)]);
         }
 
         return $this->httpClient->request($method, $url, $requestOptions);


### PR DESCRIPTION
Added the ability to retrieve the embed token for reports, updated the json post body through the guzzle client and changed the group URL to the production version.